### PR TITLE
fix timestamp to use seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const API_URL = 'https://slack.com/api'
  * @param {Boolean} onlyOldFiles
  */
 function accessFiles (token, onlyOldFiles) {
-  const thirtyDaysAgo = new Date().getTime() - 30 * (1000 * 60 * 60 * 24)
+  const thirtyDaysAgo = Math.floor(new Date().getTime() / 1000) - 30 * 86400;
 
   got(`${API_URL}/files.list`, {
     body: {


### PR DESCRIPTION
The Slack API appears to use standard unix timestamps (seconds since the epoch), but JavaScript Date.getTime returns millisecond timestamps. I've converted the timestamp calculation to return it in the way that Slack is expecting it.